### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -152,8 +152,8 @@ def check_connection():
         connected = device.web3_http.is_connected()
         return jsonify({"connected": connected})
     except Exception as e:
-        logger.error(f"블록체인 연결 확인 중 오류: {e}")
-        return jsonify({"connected": False, "error": str(e)}), 500
+        logger.error(f"블록체인 연결 확인 중 오류: {e}", exc_info=True)
+        return jsonify({"connected": False, "error": "블록체인 연결 중 오류가 발생했습니다."}), 500
 
 
 @app.route("/api/device/updates", methods=["GET"])


### PR DESCRIPTION
Potential fix for [https://github.com/HSU-Blocker/Blocker_Device/security/code-scanning/4](https://github.com/HSU-Blocker/Blocker_Device/security/code-scanning/4)

To fix the problem, the code should not return the exception message (`str(e)`) directly to the API client. Instead, log the full exception message (and optionally the stack trace) using the internal logger for developers/administrators and return a generic error message in the API response. This provides adequate debugging information for server-side analysis without exposing implementation details to the user. Modify backend/api.py, line 156, so that only a generic error message is sent to the client (e.g., "블록체인 연결 중 오류가 발생했습니다."), or simply indicate failure, omitting any details from the exception.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
