### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -165,7 +165,7 @@ def check_updates():
         return jsonify({"updates": updates})
     except Exception as e:
         logger.error(f"업데이트 확인 실패: {e}")
-        return jsonify({"updates": [], "error": str(e)}), 500
+        return jsonify({"updates": [], "error": "업데이트 확인 중 오류 발생"}), 500
 
 
 # 디바이스 클라이언트 인스턴스를 반환하는 함수 추가


### PR DESCRIPTION
Potential fix for [https://github.com/HSU-Blocker/Blocker_Device/security/code-scanning/5](https://github.com/HSU-Blocker/Blocker_Device/security/code-scanning/5)

To address the information exposure, we should modify the exception handling in the `/api/device/updates` endpoint so that details of the error (specifically, those present in `str(e)`) are NOT returned in the API response. Instead, log the full error on the server for debugging, and return only a generic error message to the client. Existing logging already captures `e`, so only the API response needs changing.

Required changes:
- In `backend/api.py`, replace the `error: str(e)` field in the JSON response at line 168 with a generic error string (e.g., "업데이트 확인 중 오류 발생").
- No additional imports or definitions are needed because logging is already present.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
