### PR TITLE
Potential fix for code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -253,7 +253,7 @@ def purchase_update():
 
     except ValueError as e:
         logger.error(f"업데이트 구매 중 값 오류: {e}")
-        return jsonify({"error": "잘못된 입력값입니다.", "details": str(e)}), 400
+        return jsonify({"error": "잘못된 입력값입니다."}), 400
     except Exception as e:
         logger.error(f"업데이트 구매 중 오류: {e}")
         import traceback


### PR DESCRIPTION
Potential fix for [https://github.com/HSU-Blocker/Blocker_Device/security/code-scanning/6](https://github.com/HSU-Blocker/Blocker_Device/security/code-scanning/6)

To fix the problem, avoid returning the exception's message directly to the user in the JSON response. Instead, return a generic user-facing error message, and ensure detailed exception information (including stack traces or error messages) are logged server-side for debugging. Specifically:
- In the `except ValueError as e` block, update the return statement on line 256 to omit `str(e)` from the user-facing message.
- Retain the logging of the actual exception message as is, so server operators can still debug the error in logs.
- No changes to imports are needed, as logging is already set up.

Edit only lines within the shown context, specifically in the relevant error handler in `purchase_update()` in backend/api.py.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
