### PR TITLE
Potential fix for code scanning alert no. 7: Information exposure through an exception

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -253,7 +253,7 @@ def purchase_update():
 
     except ValueError as e:
         logger.error(f"업데이트 구매 중 값 오류: {e}")
-        return jsonify({"error": "잘못된 입력값입니다.", "details": str(e)}), 400
+        return jsonify({"error": "잘못된 입력값입니다."}), 400
     except Exception as e:
         logger.error(f"업데이트 구매 중 오류: {e}")
         import traceback
@@ -261,7 +261,7 @@ def purchase_update():
         logger.error(traceback.format_exc())
         return (
             jsonify(
-                {"error": "업데이트 구매 중 오류가 발생했습니다.", "details": str(e)}
+                {"error": "업데이트 구매 중 오류가 발생했습니다."}
             ),
             500,
         )


### PR DESCRIPTION
Potential fix for [https://github.com/HSU-Blocker/Blocker_Device/security/code-scanning/7](https://github.com/HSU-Blocker/Blocker_Device/security/code-scanning/7)

To fix the issue, you should return only a generic error message to clients when an unexpected exception occurs, while continuing to log the full stack trace to the server logs for debugging purposes. Specifically, you should remove `str(e)` from the `"details"` field in JSON responses to the user in the generic `Exception` block of the `/api/device/updates/purchase` endpoint. For the ValueError case, you can keep a minimal message if you are sure it doesn't leak sensitive info, otherwise, return a generic input error. Only modify the code region in `backend/api.py` where these responses are constructed, ensuring that no exception content is returned to external clients. No new imports are needed unless you want to standardize error messages elsewhere.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
