### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/client/device_client.py
+++ b/client/device_client.py
@@ -129,7 +129,7 @@ class IoTDeviceClient:
             # 개인키 로드
             device_secret_key_file = os.path.join(KEY_DIR, "device_secret_key_file.bin")
             self.device_secret_key = self.cpabe.load_device_secret_key(device_secret_key_file)
-            logger.info(f"SKd: {self.device_secret_key}")
+            logger.info("기기 비밀키 로드 완료")  # SKd (Device secret key) loaded (value not logged)
 
         except Exception as e:
             logger.error(f"키 로드 중 오류 발생: {e}")


### PR DESCRIPTION
Potential fix for [https://github.com/HSU-Blocker/Blocker_Device/security/code-scanning/1](https://github.com/HSU-Blocker/Blocker_Device/security/code-scanning/1)

To fix this issue, we should remove or redact logging of sensitive key data. Specifically, the line that logs the device secret key in cleartext (`logger.info(f"SKd: {self.device_secret_key}")`) should not display the key itself. If logging is needed to track successful key loading for debugging, we should log only non-sensitive metadata (such as successful load events, key file names, or, at most, a hashed digest or truncated identifier of the key). The optimal approach is to log a generic success message or, if necessary, a truncated hash of the key for traceability without revealing the secret.

Changes required:
- In file `client/device_client.py`, within the method `_load_keys`, change or remove the logging call on line 132 so that the secret key value is not logged.
- Optionally, we can log that the secret key was loaded (without printing the key value), or log only a hash of the key for auditing (if that is justified).

No new imports are required if we simply redact. If we choose to log a hash (e.g., SHA-256 truncated), the standard `hashlib` import is already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
