### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/client/device_client.py
+++ b/client/device_client.py
@@ -458,7 +458,8 @@ class IoTDeviceClient:
             
             # 3. CP-ABE로 암호화된 대칭키(Ec) 복호화하여 대칭키(kbj) 획득
             try:
-                logger.info(f"디바이스 속성 (SKd): {[s.strip() for s in self.device_secret_key['S']]}")
+                # logger.info(f"디바이스 속성 (SKd): {[s.strip() for s in self.device_secret_key['S']]}")
+                logger.info(f"디바이스 secret 속성(SKd) 사용 (총 {len(self.device_secret_key['S'])}개)")
                 
                 # 복호화된 대칭키 확인
                 decrypted_kbj = self.decrypt_cpabe(encrypted_key_json, self.public_key, self.device_secret_key)


### PR DESCRIPTION
Potential fix for [https://github.com/HSU-Blocker/Blocker_Device/security/code-scanning/2](https://github.com/HSU-Blocker/Blocker_Device/security/code-scanning/2)

To resolve this issue, we must ensure that no secret key material (or anything plausibly sensitive) is ever logged. Specifically, line 461 logs the full value of `self.device_secret_key['S']` in clear-text, which is unsafe. The best fix is to remove this logging statement entirely, or if minimal logging is required for debugging, log only the type, length, or a non-sensitive property instead. For example, log the presence of the key or the count of attributes, never the actual values. Only change line 461 (and any related lines if required for context), leaving the rest of the code untouched. No external dependencies or method definitions are required for simple removal or minimal logging substitutes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
