### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/client/device_client.py
+++ b/client/device_client.py
@@ -590,7 +590,7 @@ class IoTDeviceClient:
             logger.error(f"CP-ABE 복호화 실패 시 상태:")
             logger.error(f"- encrypted_key: {encrypted_key}")
             logger.error(f"- public_key: {public_key}")
-            logger.error(f"- device_secret_key: {device_secret_key}")
+            logger.error(f"- device_secret_key: [REDACTED]")
             return None
 
     def get_refunded_updates(self):


### PR DESCRIPTION
Potential fix for [https://github.com/HSU-Blocker/Blocker_Device/security/code-scanning/3](https://github.com/HSU-Blocker/Blocker_Device/security/code-scanning/3)

To fix the problem, remove or redact any logging of sensitive data. For line 593, this means we must **not log** the value of `device_secret_key` directly.  
Instead, we should log only non-sensitive metadata if needed (e.g., type, length, or a digest/hash), or simply omit the key entirely from logs.  
To keep debugging useful, if logging is necessary, it can be replaced with a constant string (“[REDACTED]”) or the length/type of the key object, but **never the actual value**.

**Where to make changes:**
- File: client/device_client.py
- Region: The logger.error statement on line 593 inside `decrypt_cpabe`.
- Remove or redact the log of `device_secret_key`.
- There are no required new imports (well-known libraries only), unless you want a hash of the object for debugging—then use `hashlib.sha256`.

If debugging demands some info about `device_secret_key`, you may log its presence, type, and size, but never its contents. For example:
```python
logger.error(f"- device_secret_key: [REDACTED] (type: {type(device_secret_key)}, length: {len(str(device_secret_key))})")
```
However, the safest route: simply redact the value.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
