### PR TITLE
Potential fix for code scanning alert no. 9: Information exposure through an exception

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -346,8 +346,10 @@ def get_update_history():
         update_history = device.get_owner_update_history()
         return jsonify({"history": update_history})
     except Exception as e:
+        import traceback
         logger.error(f"업데이트 이력 조회 실패: {e}")
-        return jsonify({"error": str(e)}), 500
+        logger.error(traceback.format_exc())
+        return jsonify({"error": "서버 오류가 발생했습니다"}), 500
 
 
 @app.route("/api/notifications", methods=["GET"])


### PR DESCRIPTION
Potential fix for [https://github.com/HSU-Blocker/Blocker_Device/security/code-scanning/9](https://github.com/HSU-Blocker/Blocker_Device/security/code-scanning/9)

To fix the problem, we should avoid returning the string representation of the Exception (`str(e)`) in the HTTP response, since it may contain sensitive information. Instead, return a generic error message to the external user, such as `"서버 오류가 발생했습니다"` ("A server error occurred"), and log the real exception server-side for debugging. Edits to make:

- In `backend/api.py`, inside the `get_update_history` function (lines 348-350), change the code to log the exception details (including the stack trace via `traceback.format_exc()`), but return only a generic error message in the response.
- If `traceback` is used for logging, it should be imported (just before logging).
- Only the lines in `get_update_history`'s exception handler should be changed.

No external dependencies are needed, just standard Python logging and `traceback`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
