### PR TITLE
Potential fix for code scanning alert no. 8: Information exposure through an exception

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -330,7 +330,7 @@ def install_update():
                 {
                     "success": False,
                     "message": "업데이트 설치 중 오류가 발생했습니다.",
-                    "error": str(e),
+                    # "error": str(e),  # 내부 정보 노출 방지: 로그에만 기록
                 }
             ),
             500,


### PR DESCRIPTION
Potential fix for [https://github.com/HSU-Blocker/Blocker_Device/security/code-scanning/8](https://github.com/HSU-Blocker/Blocker_Device/security/code-scanning/8)

To resolve the issue, only a generic error message should be sent to the client, while the detailed error and stack trace should be logged internally for developers. Specifically, in the `except Exception as e` block in the `/api/device/install_update` endpoint, you should remove `"error": str(e)` from the JSON response, and only return a generic message (e.g., `"업데이트 설치 중 오류가 발생했습니다."`). The detailed exception (`str(e)`) and stack trace should continue to be written to logs using `logger.error`. Only change the exception handler for this endpoint (line 323 onwards) as flagged. No additional methods/imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
